### PR TITLE
Added support for setting bugfix indicator words

### DIFF
--- a/bin/bugspots
+++ b/bin/bugspots
@@ -17,6 +17,11 @@ OptionParser.new do |opts|
     options[:depth] = d.to_i
   end
   
+  # Option: Set Bugfix Indicator
+  opts.on('-w', '--words ["w1,w2"]', 'bugfix indicator, ie: "fixes,closed"') do |words|
+    options[:words] = words
+  end
+
   # Option: Set Timestamp Display
   opts.on('--display-timestamps', 'show timestamps of each identified fix commit') do |dt|
     options[:display_timestamps] = true
@@ -28,7 +33,7 @@ options[:depth] ||= 500
 
 puts "Scanning #{ARGV[0]} repo".foreground(:green)
 
-fixes, spots = Bugspots.scan(ARGV[0], options[:depth])
+fixes, spots = Bugspots.scan(ARGV[0], options[:depth], options[:words])
 
 puts "\tFound #{fixes.size} bugfix commits, with #{spots.size} hotspots:".foreground(:yellow)
 puts

--- a/lib/bugspots/scanner.rb
+++ b/lib/bugspots/scanner.rb
@@ -5,12 +5,18 @@ module Bugspots
   Fix = Struct.new(:message, :date, :files)
   Spot = Struct.new(:file, :score)
 
-  def self.scan(repo, depth = 500)
+  def self.scan(repo, depth = 500, words = nil)
     repo = Grit::Repo.new(repo)
     fixes = []
 
+    if words
+      message_matchers = /#{words.split(',').join('|')}/
+    else
+      message_matchers = /fix(es|ed)|close(s|d)/
+    end
+
     repo.commits('master', depth).each do |commit|  
-      if commit.message =~ /fix(es|ed)|close(s|d)/
+      if commit.message =~ message_matchers
         files = commit.stats.files.map {|s| s.first}    
         fixes << Fix.new(commit.short_message, commit.date, files)
       end


### PR DESCRIPTION
This should allow the tool to work across different peoples commit styles.

Eventually should probably allow them to set prefs in a config file, and probably refactor the main lib in support of that... but until then ;)

`-w, --words ["w1,w2"]            bugfix indicator, ie: "fixes,closed"`

Cheers.
