### PR TITLE
Allow imperative form of 'fix'.

### DIFF
--- a/lib/bugspots/scanner.rb
+++ b/lib/bugspots/scanner.rb
@@ -12,7 +12,7 @@ module Bugspots
     if words
       message_matchers = /#{words.split(',').join('|')}/
     else
-      message_matchers = /fix(es|ed)?|close(s|d)/i
+      message_matchers = /fix(es|ed)?|close(s|d)?/i
     end
 
     repo.commits(branch, depth).each do |commit|  


### PR DESCRIPTION
This one-character change lets bugspots scan for commit messages like "Fix blah blah".

This style is consistent with git's own messages, as explained by the Pope:

> Write your commit message in the present tense: "Fix bug" and not "Fixed
> bug."  This convention matches up with commit messages generated by
> commands like git merge and git revert.

http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
