### PR TITLE
Check branch existence

### DIFF
--- a/lib/bugspots/scanner.rb
+++ b/lib/bugspots/scanner.rb
@@ -7,6 +7,9 @@ module Bugspots
 
   def self.scan(repo, branch = "master", depth = 500, words = nil)
     repo = Grit::Repo.new(repo)
+    unless repo.branches.find { |e| e.name == branch }
+      raise ArgumentError, "no such branch in the repo: #{branch}"
+    end
     fixes = []
 
     if words


### PR DESCRIPTION
Now 'git-bugspots /git/ruby' raises an ArgumentError because the default
branch name is 'master' (CRuby's 'master' is 'trunk')
