### PR TITLE
Improve the default regexp

### DIFF
--- a/lib/bugspots/scanner.rb
+++ b/lib/bugspots/scanner.rb
@@ -12,7 +12,7 @@ module Bugspots
     end
     fixes = []
 
-    regex ||= /fix(es|ed)?|close(s|d)?/i
+    regex ||= /\b(fix(es|ed)?|close(s|d)?)\b/i
 
     tree = repo.tree(branch)
 


### PR DESCRIPTION
Hi,

the regexp was matching terms like fixtures, prefix or closet. I've added word boundary anchors to avoid that.
