### PR TITLE
handle spaces in paths for git-bugspots

### DIFF
--- a/bin/git-bugspots
+++ b/bin/git-bugspots
@@ -4,4 +4,4 @@ if ARGV.empty? or not Dir.exists? ARGV[0]
   ARGV.unshift Dir.pwd
 end
 
-exec("bugspots #{ARGV.join(' ')}")
+exec 'bugspots', ARGV.join(' ')


### PR DESCRIPTION
I tried

```
$ git bugspots PATH\ TO\ REPO\ WITH\ SPACES
```

and got an error, and this seemed to fix it.
