### PR TITLE
Add support for repairing UTF encoding issues

### DIFF
--- a/lib/bugspots/scanner.rb
+++ b/lib/bugspots/scanner.rb
@@ -17,7 +17,7 @@ module Bugspots
     walker.sorting(Rugged::SORT_TOPO | Rugged::SORT_REVERSE)
     walker.push(repo.branches[branch].target)
     walker.each do |commit|
-      if commit.message =~ regex
+      if commit.message.scrub =~ regex
         files = commit.diff(commit.parents.first).deltas.collect do |d|
           d.old_file[:path]
         end


### PR DESCRIPTION
In large repos, sometimes come across UTF encoding issues that causes bugspots to error before completion.

eg. bugspots/scanner.rb:20:in `=~': invalid byte sequence in UTF-8 (ArgumentError)