### PR TITLE
fix cli argument from git extension

### DIFF
--- a/bin/git-bugspots
+++ b/bin/git-bugspots
@@ -1,7 +1,10 @@
 #!/usr/bin/env ruby
 
+require 'shellwords'
+
 if ARGV.empty? or not Dir.exists? ARGV[0]
   ARGV.unshift Dir.pwd
 end
 
-exec 'bugspots', ARGV.join(' ')
+cmd = "bugspots #{Shellwords.escape(ARGV[0])} #{ARGV[1..-1].join(' ')}"
+exec cmd


### PR DESCRIPTION
#20 broke the cli argument from git extension e.g `git bugspots -d 500`
This PR fixes this issue using `shellwords`.

error log. 
```
$ ./bin/git-bugspots -d 500
Scanning /Users/ken/Google Drive/proto/ruby/bugspots -d 500 repo
/Users/ken/Google Drive/proto/ruby/bugspots -d 500
/Users/ken/Google Drive/proto/ruby/bugspots -d 500
/Users/ken/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/bugspots-0.2.1/lib/bugspots/scanner.rb:11:in `new': Failed to resolve path '/Users/ken/Google Drive/proto/ruby/bugspots -d 500': No such file or directory (Rugged::OSError)
	from /Users/ken/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/bugspots-0.2.1/lib/bugspots/scanner.rb:11:in `scan'
	from /Users/ken/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/bugspots-0.2.1/bin/bugspots:54:in `<top (required)>'
	from /Users/ken/.rbenv/versions/2.2.0/bin/bugspots:23:in `load'
	from /Users/ken/.rbenv/versions/2.2.0/bin/bugspots:23:in `<main>'
```
The issue is that bugspots interprets ` /Users/ken/Google Drive/proto/ruby/bugspots -d 500 ` as PATH for git repository not ` /Users/ken/Google Drive/proto/ruby/bugspots`


BTW, Is depth parameter  used in scanner? It look like `depth` is not used any more. I can make another PR for this. 
